### PR TITLE
os2 and name expect Buffer but may get String

### DIFF
--- a/lib/decompress.js
+++ b/lib/decompress.js
@@ -3,7 +3,7 @@ var zlib = require('zlib');
 
 module.exports = function (buf, origLength, cb) {
 	return new Promise(function (resolve, reject) {
-		if (buf.length == origLength) cb(buf.toString(), resolve, reject);
+		if (buf.length == origLength) cb(buf, resolve, reject);
 		else {
 			zlib.inflate(buf, function (err, contents) {
 				if (err) reject()


### PR DESCRIPTION
Hello, thanks for this module.
I have found a case with a font that I got an error in `lib/os2/index.js` that `readUInt16BE is not a function` and then I saw that the`if` that I changed here, returns a `String` but `lib/os2` and `lib/name` expect  `Buffer`.